### PR TITLE
Implementing .Log() after .Limit() in query builder

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -46,6 +46,7 @@ type SelectModifier interface {
 type SelectBounder interface {
 	Exec() (*sql.Rows, error)
 	ExecContext(ctx context.Context) (*sql.Rows, error)
+	Log() (string, []any)
 }
 
 type SelectThirdLevel interface {

--- a/nexom.go
+++ b/nexom.go
@@ -122,6 +122,10 @@ func (s *sb) ExecContext(ctx context.Context) (*sql.Rows, error) {
 	return s.Exec()
 }
 
+func (s *sb) Log() (string, []any) {
+	return s.qb.SelectQuery()
+}
+
 func (s *ss) Join(tableName string) SelectModifier {
 	s.qb.joinStatement = "JOIN " + tableName + " "
 	return &sm{qb: s.qb}


### PR DESCRIPTION
## Changes

- Added `Log() (string, []any)` to `SelectBounder` interface to allow method chaining with `.Log()` after `.Limit()`.
- The `*sb` struct must also implement the `Log()` method because `Limit()` returns `&sb{qb: s.qb}`. Thus, I added the function `func (s *sb) Log() (string, []any)`.
- The `*sb` now fulfills the `SelectBounder` interface.

## Testing

- I ran a quick method chaining in a function and it compiles with no issues.

```go
func test() {
	users := New("driver", "details").NewOrm("users")
	users.Select("username").Where("id = ?", 1).Limit(10).Log()
}
```